### PR TITLE
Fix CoreText font location + build fixes for macOS

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -10,6 +10,7 @@ project('editor', 'cpp',
 deps = [
   dependency('GL'),
   dependency('sdl2', default_options: ['werror=false', 'warning_level=0']),
+  dependency('freetype2'),
 ]
 
 srcs = []

--- a/src/Platform/LocateFontCoreText.cxx
+++ b/src/Platform/LocateFontCoreText.cxx
@@ -31,13 +31,13 @@ LocateFontFile(const FontFaceProperties &font_face) {
     return std::nullopt;
   }
 
-  CFStringRef url_str = CFURLGetString(url);
-  url_str = (CFStringRef)CFRetain(url_str);
+  CFStringRef path_str = CFURLCopyFileSystemPath(url, kCFURLPOSIXPathStyle);
+  path_str = (CFStringRef)CFRetain(path_str);
 
-  std::string path(CFStringGetCStringPtr(url_str, kCFStringEncodingUTF8),
-                   CFStringGetLength(url_str));
+  std::string path(CFStringGetCStringPtr(path_str, kCFStringEncodingUTF8),
+                   CFStringGetLength(path_str));
 
-  CFRelease(url_str);
+  CFRelease(path_str);
   CFRelease(font_ref);
   CFRelease(cf_str);
   return path;

--- a/src/Platform/LocateFontCoreText.cxx
+++ b/src/Platform/LocateFontCoreText.cxx
@@ -10,7 +10,7 @@ void LocateFontDeinit() {}
 /* TODO: use more than just font family name on macos */
 /* TODO: release any allocate data */
 std::optional<std::string>
-LocateFontFile(const FontFaceProperties font_face &) {
+LocateFontFile(const FontFaceProperties &font_face) {
   CFStringRef cf_str = CFStringCreateWithCString(
       nullptr, font_face.family_name.c_str(), kCFStringEncodingUTF8);
   if (cf_str == nullptr)
@@ -32,7 +32,7 @@ LocateFontFile(const FontFaceProperties font_face &) {
   }
 
   CFStringRef url_str = CFURLGetString(url);
-  url_str = CFRetain(url_str);
+  url_str = (CFStringRef)CFRetain(url_str);
 
   std::string path(CFStringGetCStringPtr(url_str, kCFStringEncodingUTF8),
                    CFStringGetLength(url_str));

--- a/src/Render/RenderContext.cxx
+++ b/src/Render/RenderContext.cxx
@@ -20,7 +20,9 @@ void GLAPIENTRY MessageCallback(GLenum source, GLenum type, GLuint id,
 
 void RenderContext::Init(void) {
   glEnable(GL_DEBUG_OUTPUT);
+#ifndef __APPLE__
   glDebugMessageCallback(MessageCallback, 0);
+#endif  /* __APPLE__ */
 
   programs = LoadShaders();
 


### PR DESCRIPTION
This PR fixes CoreText font location. The existing implementation retrieves a URL for the font, which is not a valid file path (e.g. `file:///System/Library/Fonts/Supplemental/Courier%20New.ttf`). This PR primarily fixes this bug by retrieving the filesystem path to the font from the URL. In addition, this PR fixes build errors in the CoreText implementation, fixes a build dependency issue (missing `freetype2` dependency), and adds a temporary band-aid patch for a missing OpenGL function on macOS (see commit for details).